### PR TITLE
feat(webui): improve UX and styling consistency

### DIFF
--- a/src/webroot/css/index.css
+++ b/src/webroot/css/index.css
@@ -72,6 +72,32 @@ a {
   color: var(--desc);
 }
 
+.action_card {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.action_card_title, .action_card_title_with_flag {
+  font-size: 1.1em;
+  padding-left: 5px;
+  padding-top: 6px;
+  padding-bottom: 2px;
+}
+
+.action_card_title_with_flag {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.action_card_description {
+  font-size: 0.9em;
+  padding-left: 5px;
+  padding-bottom: 6px;
+  line-height: 1.3;
+}
+
 .center {
   justify-content: center;
   align-self: center;
@@ -189,8 +215,12 @@ body {
   z-index: 1;
 }
 
-.page_loader_main_push {
-  animation: pageLoaderMainPush 400ms cubic-bezier(0.2, 0, 0, 1) both;
+.page_loader_main_in {
+  animation: pageLoaderMainIn 350ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.page_loader_main_out {
+  animation: pageLoaderMainOut 350ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
 }
 
 .page_loader_mini_layer {
@@ -217,8 +247,8 @@ body {
 
 @keyframes pageLoaderMainIn {
   0% {
-    transform: translateX(var(--page_loader_main_in_from, 34%));
-    opacity: 0.7;
+    transform: translateX(var(--page_loader_main_in_from, 30px));
+    opacity: 0;
   }
   100% {
     transform: translateX(0%);
@@ -232,8 +262,8 @@ body {
     opacity: 1;
   }
   100% {
-    transform: translateX(var(--page_loader_main_out_to, -24%));
-    opacity: 0.55;
+    transform: translateX(var(--page_loader_main_out_to, -30px));
+    opacity: 0;
   }
 }
 

--- a/src/webroot/index.css
+++ b/src/webroot/index.css
@@ -1,3 +1,14 @@
+* {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  outline: none;
+}
+
 .loader {
   border: 6px solid var(--icon-bc);
   border-top: 6px solid var(--icon);

--- a/src/webroot/js/pages/actions/index.css
+++ b/src/webroot/js/pages/actions/index.css
@@ -76,10 +76,6 @@ input:checked + .slider {
   margin-left: 3px;
 }
 
-.normal_title {
-  font-size: 16px;
-}
-
 .flag_content {
   padding: 4px 8px 4px 8px;
   border-radius: 5px;

--- a/src/webroot/js/pages/animator.js
+++ b/src/webroot/js/pages/animator.js
@@ -20,36 +20,32 @@ function waitForAnimationEnd(element, fallbackMs = 280) {
 export async function runMainPageTransition(currentPageContent, nextPageContent, direction = 1) {
   /* INFO: MD3 shared-axis style navigation keeps pages side-by-side and pushes them together. */
   const viewport = currentPageContent.parentElement
-  const incomingFrom = direction > 0 ? '100%' : '-100%'
-  const outgoingTo = direction > 0 ? '-100%' : '100%'
+  const incomingFrom = direction > 0 ? '30px' : '-30px'
+  const outgoingTo = direction > 0 ? '-30px' : '30px'
 
   viewport.classList.add('page_loader_main_viewport_transition')
 
   nextPageContent.style.display = 'block'
-  currentPageContent.style.setProperty('--page_loader_main_from', '0%')
-  currentPageContent.style.setProperty('--page_loader_main_to', outgoingTo)
-  nextPageContent.style.setProperty('--page_loader_main_from', incomingFrom)
-  nextPageContent.style.setProperty('--page_loader_main_to', '0%')
+  currentPageContent.style.setProperty('--page_loader_main_out_to', outgoingTo)
+  nextPageContent.style.setProperty('--page_loader_main_in_from', incomingFrom)
 
   currentPageContent.style.pointerEvents = 'none'
   nextPageContent.style.pointerEvents = 'none'
-  currentPageContent.classList.add('page_loader_main_transition', 'page_loader_main_push')
-  nextPageContent.classList.add('page_loader_main_transition', 'page_loader_main_push')
+  currentPageContent.classList.add('page_loader_main_transition', 'page_loader_main_out')
+  nextPageContent.classList.add('page_loader_main_transition', 'page_loader_main_in')
 
   /* INFO: Force style application before animation starts */
   nextPageContent.getBoundingClientRect()
 
   await Promise.all([
-    waitForAnimationEnd(currentPageContent, 440),
-    waitForAnimationEnd(nextPageContent, 440),
+    waitForAnimationEnd(currentPageContent, 380),
+    waitForAnimationEnd(nextPageContent, 380),
   ])
 
-  currentPageContent.classList.remove('page_loader_main_transition', 'page_loader_main_push')
-  nextPageContent.classList.remove('page_loader_main_transition', 'page_loader_main_push')
-  currentPageContent.style.removeProperty('--page_loader_main_from')
-  currentPageContent.style.removeProperty('--page_loader_main_to')
-  nextPageContent.style.removeProperty('--page_loader_main_from')
-  nextPageContent.style.removeProperty('--page_loader_main_to')
+  currentPageContent.classList.remove('page_loader_main_transition', 'page_loader_main_out')
+  nextPageContent.classList.remove('page_loader_main_transition', 'page_loader_main_in')
+  currentPageContent.style.removeProperty('--page_loader_main_out_to')
+  nextPageContent.style.removeProperty('--page_loader_main_in_from')
   currentPageContent.style.removeProperty('pointer-events')
   nextPageContent.style.removeProperty('pointer-events')
   viewport.classList.remove('page_loader_main_viewport_transition')


### PR DESCRIPTION
- Disabled global text selection and touch callouts to make the UI feel more like a native app.

- Removed default tap highlight boxes (blue outlines) from interactive elements like buttons and the navigation bar.

- Updated page transition animations to use the modern Material Design 3 Shared Axis pattern (smooth fading and gliding) for a more premium feel.

- Fixed an issue where title font sizes would inconsistently jump between the Actions and Settings pages by standardizing the .action_card_title typography and removing conflicting hardcoded sizes.