### PR TITLE
fix(hiding): do_maps_hiding was a no-op (always-true filter)

### DIFF
--- a/src/lib/hiding.c
+++ b/src/lib/hiding.c
@@ -187,10 +187,11 @@ int do_maps_hiding(struct api_table *api_table, JNIEnv *tw_env) {
   for (size_t i = 0; i < g_maps->size; i++) {
     struct map *map = &g_maps->maps[i];
 
-    if (map->dev != st.st_dev || !str_starts_with(map->path, "/system/") ||
-        !str_starts_with(map->path, "/vendor/") ||
-        !str_starts_with(map->path, "/product/") ||
-        !str_starts_with(map->path, "/system_ext/")
+    if (map->path == NULL || map->dev != st.st_dev ||
+        str_starts_with(map->path, "/data/adb/modules/rezygisk/") ||
+        str_starts_with(map->path, "/data/adb/modules/treat_wheel/") ||
+        (!str_starts_with(map->path, "/data/adb/") &&
+        !str_starts_with(map->path, "/data/local/tmp/"))
     ) {
       continue;
     }


### PR DESCRIPTION
## What

`do_maps_hiding()` never hid any map: the filter condition was always true, so every iteration hit `continue` and nothing was ever morphed. The feature is a no-op on `main`.

This is the bug reported in #16.

## Why it was always true

A real path starts with at most one of `/system/`, `/vendor/`, `/product/`, `/system_ext/`. So at least three of the four `!str_starts_with(...)` terms are always true, and being OR-ed together the whole condition is unconditionally true, regardless of `map->dev`.

You can confirm at runtime: `MH: Maps hiding is enabled` and `MH: Finished hiding maps traces` are logged, but never a single `MH: Hiding suspicious map: ...`.

## The fix

Replace the broken system-partition exclusion with a positive match on the injection roots that actually leak in an injected process, plus a `NULL` guard for anonymous mappings:

- hide maps under `/data/adb/` or `/data/local/tmp/`
- leave everything else untouched (including the process's own `/data/app/...` libraries, which a naive `!`-removal would have wrongly morphed)
- leave `rezygisk` and `treat_wheel` visible **on purpose**: Treat Wheel unloads itself via `DLCLOSE_MODULE_LIBRARY` (so it leaves the maps on its own), and ReZygisk is the live loader that performs that unload, so morphing their own mappings would fight the unload path

The diff touches only the `if` condition. No reformatting, no log-format changes, no changes to the mmap/mremap logic. Style follows the existing file (2-space indent, `!x` rather than `x == false`).

Refs #16
